### PR TITLE
Remove 'go' from help message

### DIFF
--- a/go-mod-bump.sh
+++ b/go-mod-bump.sh
@@ -26,9 +26,8 @@ function echoerr() {
 
 if [ -z "$1" ]; then
     echoerr <<EOF
-go-mod-bump: nothing to do, set argument 'all', 'go' or module name(s), for example:
+go-mod-bump: nothing to do, set argument 'all' or module name(s), for example:
     go-mod-bump all
-    go-mod-bump go
     go-mod-bump github.com/xorcare/pointer
     go-mod-bump github.com/xorcare/pointer github.com/xorcare/tornado
 EOF


### PR DESCRIPTION
The Go update has implicit behavior, especially in go1.22, so I'll remove mention of this feature for now.

In go1.22+ the toolchain version is updated in addition with Go version, and it is not clear yet how it will work better with this.