### PR TITLE
Replace alias 'cm' with full command 'commit'

### DIFF
--- a/go-mod-bump.sh
+++ b/go-mod-bump.sh
@@ -127,7 +127,7 @@ function bump_module() {
 
     git reset HEAD -- . >/dev/null
     git add go.mod go.sum >/dev/null
-    git cm -a -m "${PREFIX}Bump ${module} from ${current_version} to ${latest_version}" >/dev/null
+    git commit -a -m "${PREFIX}Bump ${module} from ${current_version} to ${latest_version}" >/dev/null
 
     echoerr "go-mod-bump: upgraded ${module} ${current_version} => [${latest_version}]"
 }


### PR DESCRIPTION
This is necessary for the command to work correctly everywhere. I have previously run this script on systems where I have set the 'cm' alias for the 'commit' command, and this did not allow me to identify the problem earlier.