### PR TITLE
Make the script skip the main module

### DIFF
--- a/go-mod-bump.sh
+++ b/go-mod-bump.sh
@@ -88,7 +88,7 @@ EOF
     exit 0
 fi
 
-GO_LIST_FORMAT_DIRECT='{{.Path}}{{if .Indirect}}<SKIP>{{end}}'
+GO_LIST_FORMAT_DIRECT='{{.Path}}{{if .Indirect}}<SKIP>{{end}}{{if .Main}}<SKIP>{{end}}'
 readonly GO_LIST_FORMAT_DIRECT
 
 # shellcheck disable=SC2068


### PR DESCRIPTION
There is no point in processing a module for which we are updating dependencies, as we won't be able to update its version anyway.

Yes, this module will still be filtered in the second stage, but there is no point in including it in the list of modules to search for updates.