### PR TITLE
Get rid of 'grep -v'

### DIFF
--- a/go-mod-bump.sh
+++ b/go-mod-bump.sh
@@ -88,13 +88,13 @@ EOF
     exit 0
 fi
 
-GO_LIST_FORMAT_DIRECT='{{.Path}}{{if .Indirect}}<SKIP>{{end}}{{if .Main}}<SKIP>{{end}}'
+GO_LIST_FORMAT_DIRECT='{{if and (not .Main) (not .Indirect)}}{{.Path}}{{end}}'
 readonly GO_LIST_FORMAT_DIRECT
 
 echoerr "go-mod-bump: fetching direct modules"
 
 # shellcheck disable=SC2068
-DIRECT_MODULES=$(go list -m -f "$GO_LIST_FORMAT_DIRECT" $@ | grep -v '<SKIP>' || true)
+DIRECT_MODULES=$(go list -m -f "$GO_LIST_FORMAT_DIRECT" $@)
 readonly DIRECT_MODULES
 
 if [ -z "$DIRECT_MODULES" ]; then
@@ -102,14 +102,13 @@ if [ -z "$DIRECT_MODULES" ]; then
     exit 0
 fi
 
-GO_LIST_FORMAT_FOR_UPDATE='{{.Path}}@{{.Version}}@{{if .Update}}{{.Update.Version}}{{end}}'
-GO_LIST_FORMAT_FOR_UPDATE+='{{if not .Update}}<SKIP>{{end}}' # skip modules without updates.
+GO_LIST_FORMAT_FOR_UPDATE='{{if .Update}}{{.Path}}@{{.Version}}@{{.Update.Version}}{{end}}'
 readonly GO_LIST_FORMAT_FOR_UPDATE
 
 echoerr "go-mod-bump: fetching latest versions of modules"
 
 # shellcheck disable=SC2086
-MODULES_FOR_UPDATE=$(go list -m -u -f "$GO_LIST_FORMAT_FOR_UPDATE" $DIRECT_MODULES | grep -v '<SKIP>' || true)
+MODULES_FOR_UPDATE=$(go list -m -u -f "$GO_LIST_FORMAT_FOR_UPDATE" $DIRECT_MODULES)
 readonly MODULES_FOR_UPDATE
 
 if [ -z "$MODULES_FOR_UPDATE" ]; then


### PR DESCRIPTION
This will simplify the code, and reduce the chance of unexpected errors. It's also more readable, even though I always wonder if there will be blank lines in the output of commands.